### PR TITLE
Fixing an npm install crash

### DIFF
--- a/nextjs-basic/package.json
+++ b/nextjs-basic/package.json
@@ -13,7 +13,7 @@
     "react-dom": "17.0.2",
     "react-transition-group": "^4.4.1",
     "primereact": "^7.0.0-rc.2",
-    "primeicons": "^4.1.0",
+    "primeicons": "^5.0.0",
     "primeflex": "^3.1.0"
   },
   "devDependencies": {

--- a/nextjs-crud/package.json
+++ b/nextjs-crud/package.json
@@ -13,7 +13,7 @@
     "react-dom": "17.0.2",
     "react-transition-group": "^4.4.1",
     "primereact": "^7.0.0-rc.2",
-    "primeicons": "^4.1.0",
+    "primeicons": "^5.0.0",
     "primeflex": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixed an npm install crash:
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: nextjs-basic@undefined
npm ERR! Found: primeicons@4.1.0
npm ERR! node_modules/primeicons
npm ERR!   primeicons@"^4.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer primeicons@"^5.0.0" from primereact@7.2.1
npm ERR! node_modules/primereact
npm ERR!   primereact@"^7.0.0-rc.2" from the root project
