### PR TITLE
Fix incorrect @import layer in index.css for theme styling

### DIFF
--- a/vite-styled-tailwind/src/index.css
+++ b/vite-styled-tailwind/src/index.css
@@ -1,7 +1,7 @@
 @layer tailwind-base, primereact, tailwind-utilities;
 
 /* IMPORTANT: Styled mode you must add the PrimeReact Theme here. Do not include in unstyled mode */
-@import 'primereact/resources/themes/lara-light-blue/theme.css' layer(primereact);
+@import 'primereact/resources/themes/lara-light-blue/theme.css';
 
 @layer tailwind-base {
   @tailwind base;


### PR DESCRIPTION
### Summary
This PR addresses an issue where the `index.css` file was importing the PrimeReact theme with an unnecessary `layer(primereact)` declaration. This was causing the theme styles to not be applied correctly in projects using TailwindCSS with PrimeReact.

### Changes Made
- Removed the `layer(primereact)` from the `@import` statement in `index.css`.
- Verified that the theme now applies correctly without affecting other styles.

### Why This Is Necessary
The incorrect usage of the `layer` directive was causing conflicts with TailwindCSS, preventing the proper application of the PrimeReact theme where Galleria CSS was not working properly. By removing the `layer(primereact)` declaration, this change ensures that the theme styles are applied as intended.

### Additional Notes
Please consider updating the TailwindCSS integration guide on the website to reflect this change, as it might help other developers avoid similar issues.

### Linked Issues
- Closes #7070 (link to the issue if applicable)
